### PR TITLE
Add "Load Logs for Preview" button

### DIFF
--- a/cli_main.cpp
+++ b/cli_main.cpp
@@ -5,51 +5,6 @@
 #include <vector>
 #include <string>
 
-// dumb and simple way to parse CSV
-std::vector<ChatMessage> parseCSV(const std::string &filename, int timeMultiplier) {
-    std::vector<ChatMessage> messages;
-    std::ifstream file(filename);
-    std::string line;
-
-    if (!file.is_open()) {
-        std::cerr << "Error: Could not open file " << filename << "\n";
-        std::exit(-1);
-    }
-
-    std::getline(file, line);
-    if (line != "time,user_name,user_color,message") {
-        std::cerr << "Error: Unexpected CSV header format.\n";
-        std::exit(-1);
-    }
-
-    while (std::getline(file, line)) {
-        std::stringstream ss(line);
-        std::string field;
-        ChatMessage msg;
-
-        std::getline(ss, field, ',');
-        msg.time = std::stoi(field) * timeMultiplier;
-
-        std::getline(ss, msg.user.name, ',');
-
-        std::getline(ss, field, ',');
-        msg.user.color = field.empty() ? getRandomColor(msg.user.name) : Color(field);
-
-        std::getline(ss, msg.message);
-
-        if (msg.message.size() >= 2 &&
-            msg.message.front() == '"' &&
-            msg.message.back() == '"') {
-            msg.message = msg.message.substr(1, msg.message.size() - 2);
-        }
-
-        messages.emplace_back(std::move(msg));
-    }
-
-    return messages;
-}
-
-
 int main(int argc, char *argv[]) {
     CLI::App app{"Chat → YTT/SRV3 subtitle generator"};
 

--- a/gui_main.cpp
+++ b/gui_main.cpp
@@ -240,7 +240,27 @@ int main(int, char **) {
                     printf("Failed to load image: %s\n", outPath);
                 NFD_FreePathU8(outPath);
             } else if (result == NFD_CANCEL) {
-
+                // Do nothing
+            } else {
+                printf("Error: %s\n", NFD_GetError());
+            }
+        }
+        if (ImGui::Button("Load Logs for Preview")) {
+            nfdu8char_t *outPath = nullptr;
+            nfdu8filteritem_t filters[1] = {{"CSV files", "csv"}};
+            nfdopendialogu8args_t args = {0};
+            args.filterList = filters;
+            args.filterCount = 1;
+            // Set the parent window handle using the GLFW binding
+            //NFD_GetNativeWindowFromGLFWWindow(window, &args.parentWindow);
+            nfdresult_t result = NFD_OpenDialogU8_With(&outPath, &args);
+            if (result == NFD_OKAY) {
+                int multiplier = 1; // TODO: some way to customize time units
+                text_overlay.messages = parseCSV(outPath, multiplier);
+                text_overlay.revalidatePreview = true;
+                NFD_FreePathU8(outPath);
+            } else if (result == NFD_CANCEL) {
+                // Do nothing
             } else {
                 printf("Error: %s\n", NFD_GetError());
             }

--- a/gui_main.cpp
+++ b/gui_main.cpp
@@ -245,7 +245,8 @@ int main(int, char **) {
                 printf("Error: %s\n", NFD_GetError());
             }
         }
-        if (ImGui::Button("Load Logs for Preview")) {
+        if (preview_texture == 0) ImGui::BeginDisabled();
+        if (ImGui::Button("Load Chat Logs for Preview")) {
             nfdu8char_t *outPath = nullptr;
             nfdu8filteritem_t filters[1] = {{"CSV files", "csv"}};
             nfdopendialogu8args_t args = {0};
@@ -265,7 +266,6 @@ int main(int, char **) {
                 printf("Error: %s\n", NFD_GetError());
             }
         }
-        if (preview_texture == 0) ImGui::BeginDisabled();
         ImGui::SliderInt("X", &p.horizontalMargin, 0, 100);
         ImGui::SliderInt("Y", &p.verticalMargin, 0, 100);
         ImGui::SliderInt("Font size", &p.fontSizePercent, 0, 300);

--- a/image_view.h
+++ b/image_view.h
@@ -29,14 +29,15 @@ struct InteractiveTextOverlay {
         return (((params.verticalMargin + N * params.verticalSpacing) * 0.96f) + 2.15f) / 100.0f;
     }
 
+    // TODO: make preview take into account the color of the nickname from the messages
     std::vector<std::pair<std::string, std::string>> preview;
     bool revalidatePreview = true;
     bool isInsidePicture = true;
 
     void generatePreview() {
         preview.clear();
-        for (const auto &[name, text]: messages) {
-            auto [username, wrapped] = wrapMessage(name, params.usernameSeparator, text, params.maxCharsPerLine);
+        for (const auto &message: messages) {
+            auto [username, wrapped] = wrapMessage(message.user.name, params.usernameSeparator, message.message, params.maxCharsPerLine);
             if (wrapped.empty()) {
                 continue;
             }
@@ -52,59 +53,59 @@ struct InteractiveTextOverlay {
         revalidatePreview = false;
     }
 
-    std::vector<std::pair<std::string, std::string>> messages = {
-            {"Sirius",        "Lorem ipsum dolor sit amet, consectetur adipiscing elit."},
-            {"Betelgeuse",    "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."},
-            {"Vega",          "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris."},
-            {"Rigel",         "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore."},
-            {"Antares",       "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia."},
-            {"Arcturus",      "Curabitur pretium tincidunt lacus. Nulla gravida orci a odio."},
-            {"Aldebaran",     "Pellentesque habitant morbi tristique senectus et netus et malesuada fames."},
-            {"Procyon",       "Maecenas sed diam eget risus varius blandit sit amet non magna."},
-            {"Capella",       "Cras mattis consectetur purus sit amet fermentum."},
-            {"Altair",        "Aenean lacinia bibendum nulla sed consectetur."},
-            {"Pollux",        "Vestibulum id ligula porta felis euismod semper."},
-            {"Spica",         "Praesent commodo cursus magna, vel scelerisque nisl consectetur et."},
-            {"Deneb",         "Nullam quis risus eget urna mollis ornare vel eu leo."},
-            {"Canopus",       "Etiam porta sem malesuada magna mollis euismod."},
-            {"Fomalhaut",     "Donec ullamcorper nulla non metus auctor fringilla."},
-            {"Bellatrix",     "Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis."},
-            {"Achernar",      "Integer posuere erat a ante venenatis dapibus posuere velit aliquet."},
-            {"Regulus",       "Sed posuere consectetur est at lobortis."},
-            {"Castor",        "Curabitur blandit tempus porttitor."},
-            {"Mira",          "Morbi leo risus, porta ac consectetur ac, vestibulum at eros."},
-            {"Alpheratz",     "Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh."},
-            {"Shaula",        "Donec id elit non mi porta gravida at eget metus."},
-            {"Zubenelgenubi", "Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor."},
-            {"Sadr",          "Integer nec odio. Praesent libero. Sed cursus ante dapibus diam."},
-            {"Nunki",         "Suspendisse potenti. Morbi fringilla convallis sapien."},
-            {"Hadar",         "Curabitur tortor. Pellentesque nibh."},
-            {"Mintaka",       "Aenean quam. In scelerisque sem at dolor."},
-            {"Alnilam",       "Maecenas mattis. Sed convallis tristique sem."},
-            {"Wezen",         "Proin ut ligula vel nunc egestas porttitor."},
-            {"Naos",          "Aliquam erat volutpat. Nulla facilisi."},
-            {"Rasalhague",    "Nam dui ligula, fringilla a, euismod sodales, sollicitudin vel, wisi."},
-            {"Markab",        "Nulla facilisi. Aenean nec eros."},
-            {"Diphda",        "Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere."},
-            {"Enif",          "Duis cursus, mi quis viverra ornare, eros dolor interdum nulla."},
-            {"Unukalhai",     "Fusce lacinia arcu et nulla."},
-            {"Gienah",        "Suspendisse in justo eu magna luctus suscipit."},
-            {"Algol",         "Curabitur at lacus ac velit ornare lobortis."},
-            {"Menkar",        "Nullam nulla eros, ultricies sit amet, nonummy id, imperdiet feugiat."},
-            {"Saiph",         "Phasellus viverra nulla ut metus varius laoreet."},
-            {"Izar",          "Quisque rutrum. Aenean imperdiet."},
-            {"Alhena",        "Etiam ultricies nisi vel augue."},
-            {"Menkalinan",    "Curabitur ullamcorper ultricies nisi."},
-            {"Avior",         "Donec mollis hendrerit risus."},
-            {"Peacock",       "Praesent egestas tristique nibh."},
-            {"Hamal",         "Curabitur blandit mollis lacus."},
-            {"Eltanin",       "Nam adipiscing. Vestibulum eu odio."},
-            {"Sadalmelik",    "Curabitur vestibulum aliquam leo."},
-            {"Ankaa",         "Pellentesque habitant morbi tristique senectus et netus et malesuada."},
-            {"Tarazed",       "Nunc nonummy metus. Vestibulum volutpat pretium libero."},
-            {"Caph",          "Duis leo. Sed fringilla mauris sit amet nibh."},
-            {"Alsephina",     "Donec sodales sagittis magna."},
-            {"Sabik",         "Fusce fermentum odio nec arcu."}
+    std::vector<ChatMessage> messages = {
+            {0, {"Sirius"},        "Lorem ipsum dolor sit amet, consectetur adipiscing elit."},
+            {0, {"Betelgeuse"},    "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."},
+            {0, {"Vega"},          "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris."},
+            {0, {"Rigel"},         "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore."},
+            {0, {"Antares"},       "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia."},
+            {0, {"Arcturus"},      "Curabitur pretium tincidunt lacus. Nulla gravida orci a odio."},
+            {0, {"Aldebaran"},     "Pellentesque habitant morbi tristique senectus et netus et malesuada fames."},
+            {0, {"Procyon"},       "Maecenas sed diam eget risus varius blandit sit amet non magna."},
+            {0, {"Capella"},       "Cras mattis consectetur purus sit amet fermentum."},
+            {0, {"Altair"},        "Aenean lacinia bibendum nulla sed consectetur."},
+            {0, {"Pollux"},        "Vestibulum id ligula porta felis euismod semper."},
+            {0, {"Spica"},         "Praesent commodo cursus magna, vel scelerisque nisl consectetur et."},
+            {0, {"Deneb"},         "Nullam quis risus eget urna mollis ornare vel eu leo."},
+            {0, {"Canopus"},       "Etiam porta sem malesuada magna mollis euismod."},
+            {0, {"Fomalhaut"},     "Donec ullamcorper nulla non metus auctor fringilla."},
+            {0, {"Bellatrix"},     "Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis."},
+            {0, {"Achernar"},      "Integer posuere erat a ante venenatis dapibus posuere velit aliquet."},
+            {0, {"Regulus"},       "Sed posuere consectetur est at lobortis."},
+            {0, {"Castor"},        "Curabitur blandit tempus porttitor."},
+            {0, {"Mira"},          "Morbi leo risus, porta ac consectetur ac, vestibulum at eros."},
+            {0, {"Alpheratz"},     "Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh."},
+            {0, {"Shaula"},        "Donec id elit non mi porta gravida at eget metus."},
+            {0, {"Zubenelgenubi"}, "Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor."},
+            {0, {"Sadr"},          "Integer nec odio. Praesent libero. Sed cursus ante dapibus diam."},
+            {0, {"Nunki"},         "Suspendisse potenti. Morbi fringilla convallis sapien."},
+            {0, {"Hadar"},         "Curabitur tortor. Pellentesque nibh."},
+            {0, {"Mintaka"},       "Aenean quam. In scelerisque sem at dolor."},
+            {0, {"Alnilam"},       "Maecenas mattis. Sed convallis tristique sem."},
+            {0, {"Wezen"},         "Proin ut ligula vel nunc egestas porttitor."},
+            {0, {"Naos"},          "Aliquam erat volutpat. Nulla facilisi."},
+            {0, {"Rasalhague"},    "Nam dui ligula, fringilla a, euismod sodales, sollicitudin vel, wisi."},
+            {0, {"Markab"},        "Nulla facilisi. Aenean nec eros."},
+            {0, {"Diphda"},        "Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere."},
+            {0, {"Enif"},          "Duis cursus, mi quis viverra ornare, eros dolor interdum nulla."},
+            {0, {"Unukalhai"},     "Fusce lacinia arcu et nulla."},
+            {0, {"Gienah"},        "Suspendisse in justo eu magna luctus suscipit."},
+            {0, {"Algol"},         "Curabitur at lacus ac velit ornare lobortis."},
+            {0, {"Menkar"},        "Nullam nulla eros, ultricies sit amet, nonummy id, imperdiet feugiat."},
+            {0, {"Saiph"},         "Phasellus viverra nulla ut metus varius laoreet."},
+            {0, {"Izar"},          "Quisque rutrum. Aenean imperdiet."},
+            {0, {"Alhena"},        "Etiam ultricies nisi vel augue."},
+            {0, {"Menkalinan"},    "Curabitur ullamcorper ultricies nisi."},
+            {0, {"Avior"},         "Donec mollis hendrerit risus."},
+            {0, {"Peacock"},       "Praesent egestas tristique nibh."},
+            {0, {"Hamal"},         "Curabitur blandit mollis lacus."},
+            {0, {"Eltanin"},       "Nam adipiscing. Vestibulum eu odio."},
+            {0, {"Sadalmelik"},    "Curabitur vestibulum aliquam leo."},
+            {0, {"Ankaa"},         "Pellentesque habitant morbi tristique senectus et netus et malesuada."},
+            {0, {"Tarazed"},       "Nunc nonummy metus. Vestibulum volutpat pretium libero."},
+            {0, {"Caph"},          "Duis leo. Sed fringilla mauris sit amet nibh."},
+            {0, {"Alsephina"},     "Donec sodales sagittis magna."},
+            {0, {"Sabik"},         "Fusce fermentum odio nec arcu."}
     };
 };
 

--- a/ytt_generator.h
+++ b/ytt_generator.h
@@ -634,6 +634,46 @@ Color getRandomColor(const std::string &username) {
 
 }
 
+// dumb and simple way to parse CSV
+std::vector<ChatMessage> parseCSV(const std::string &filename, int timeMultiplier) {
+    std::vector<ChatMessage> messages;
+    std::ifstream file(filename);
+    std::string line;
 
+    if (!file.is_open()) {
+        std::cerr << "Error: Could not open file " << filename << "\n";
+        std::exit(-1);
+    }
 
+    std::getline(file, line);
+    if (line != "time,user_name,user_color,message") {
+        std::cerr << "Error: Unexpected CSV header format.\n";
+        std::exit(-1);
+    }
 
+    while (std::getline(file, line)) {
+        std::stringstream ss(line);
+        std::string field;
+        ChatMessage msg;
+
+        std::getline(ss, field, ',');
+        msg.time = std::stoi(field) * timeMultiplier;
+
+        std::getline(ss, msg.user.name, ',');
+
+        std::getline(ss, field, ',');
+        msg.user.color = field.empty() ? getRandomColor(msg.user.name) : Color(field);
+
+        std::getline(ss, msg.message);
+
+        if (msg.message.size() >= 2 &&
+            msg.message.front() == '"' &&
+            msg.message.back() == '"') {
+            msg.message = msg.message.substr(1, msg.message.size() - 2);
+        }
+
+        messages.emplace_back(std::move(msg));
+    }
+
+    return messages;
+}


### PR DESCRIPTION
Sometimes you want to test how specific messages and nicknames look like with your config. So an ability to just load your chat log is very useful for this use case and not very difficult to add. We are loading them the same way we do it in `subtitles_generator`.

Please let me know if you see any problems with this PR.